### PR TITLE
Add business metrics to final model

### DIFF
--- a/models/zendesk__ticket_metrics.sql
+++ b/models/zendesk__ticket_metrics.sql
@@ -159,7 +159,12 @@ left join ticket_comments
 select
   calendar_hour_metrics.*,
   business_hour_metrics.first_resolution_business_minutes,
-  business_hour_metrics.full_resolution_business_minutes
+  business_hour_metrics.full_resolution_business_minutes,
+  business_hour_metrics.first_reply_time_business_minutes,
+  business_hour_metrics.agent_wait_time_in_business_minutes,
+  business_hour_metrics.requester_wait_time_in_business_minutes,
+  business_hour_metrics.agent_work_time_in_business_minutes,
+  business_hour_metrics.on_hold_time_in_business_minutes
 
 from calendar_hour_metrics
 


### PR DESCRIPTION
The final model erroneously did not pull all business metrics.  This PR updates this.