### PR TITLE
Conditional statement addition for disabled model fields

### DIFF
--- a/models/intermediate/int_zendesk__user_aggregates.sql
+++ b/models/intermediate/int_zendesk__user_aggregates.sql
@@ -1,5 +1,3 @@
---To disable this model, set the using_user_tags variable within your dbt_project.yml file to False.
-{{ config(enabled=var('using_user_tags', True)) }}
 with users as (
   select *
   from {{ ref('stg_zendesk__user') }}
@@ -30,8 +28,11 @@ with users as (
     {% endif %}
   from users
 
+  --If you use user tags this will be included, if not it will be ignored.
+  {% if var('using_user_tags', True) %}
   left join user_tag_aggregate
     using(user_id)
+  {% endif %}
 )
 
 select *

--- a/models/ticket_history/int_zendesk__updater_information.sql
+++ b/models/ticket_history/int_zendesk__updater_information.sql
@@ -8,19 +8,32 @@ with users as (
 
 ), final as (
     select
-        users.user_id as updater_user_id, 
-        users.name as updater_name, 
-        users.role as updater_role, 
-        users.email as updater_email, 
-        users.external_id as updater_external_id, 
-        users.locale as updater_locale, 
-        users.is_active as updater_is_active, 
-        users.user_tags as updater_user_tags, 
-        users.last_login_at as updater_last_login_at, 
-        users.time_zone as updater_time_zone, 
-        organizations.organization_id as updater_organization_id, 
-        organizations.domain_names as updater_organization_domain_names, 
-        organizations.organization_tags as updater_organization_organization_tags
+        users.user_id as updater_user_id
+        ,users.name as updater_name
+        ,users.role as updater_role
+        ,users.email as updater_email
+        ,users.external_id as updater_external_id
+        ,users.locale as updater_locale
+        ,users.is_active as updater_is_active
+
+        --If you use user tags this will be included, if not it will be ignored.
+        {% if var('using_user_tags', True) %}
+        ,users.user_tags as updater_user_tags
+        {% endif %}
+
+        ,users.last_login_at as updater_last_login_at
+        ,users.time_zone as updater_time_zone
+        ,organizations.organization_id as updater_organization_id
+
+        --If you use using_domain_names tags this will be included, if not it will be ignored.
+        {% if var('using_domain_names', True) %}
+        ,organizations.domain_names as updater_organization_domain_names
+        {% endif %}
+
+        --If you use organization tags this will be included, if not it will be ignored.
+        {% if var('using_organization_tags', True) %}
+        ,organizations.organization_tags as updater_organization_organization_tags
+        {% endif %}
     from users
 
     left join organizations


### PR DESCRIPTION
This PR includes fixes to the `int_zendesk__user_aggregates` and `int_zendesk__updater_information` models which adds conditional statements to remove fields if the user disables the upstream models.