### PR TITLE
trailing comma bug fix

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'zendesk'
-version: '0.3.0'
+version: '0.3.1'
 config-version: 2
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 on-run-start: '{{ fivetran_utils.empty_variable_warning("ticket_field_history_columns", "zendesk_ticket_field_history") }}'

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'zendesk_integration_tests'
-version: '0.3.0'
+version: '0.3.1'
 
 require-dbt-version: [">=0.18.0", "<0.20.0"]
 profile: 'integration_tests'

--- a/models/zendesk__ticket_enriched.sql
+++ b/models/zendesk__ticket_enriched.sql
@@ -113,11 +113,11 @@ with ticket as (
         assignee_updates.last_updated as assignee_ticket_last_update_at,
         assignee.last_login_at as assignee_last_login_at,
         ticket_group.name as group_name,
-        organization.name as organization_name,
+        organization.name as organization_name
 
         --If you use using_user_tags this will be included, if not it will be ignored.
         {% if var('using_user_tags', True) %}
-        requester.user_tags as requester_tag,
+        ,requester.user_tags as requester_tag,
         submitter.user_tags as submitter_tag,
         assignee.user_tags as assignee_tag
         {% endif %}


### PR DESCRIPTION
This PR includes the following updates:

- Removes a trailing comma prior to a conditional that can be disabled. This will result in an error if a user not on BigQuery disables the `using_user_tags` variable.

Please note another PR #24 is open for Postgres compatibility. This change is included within that PR. However, I would prefer the customer confirm the package is working as intended before merging. In my opinion this change is a bug fix that should be implemented and released asap.