### PR TITLE
Fix/field history incremental update

### DIFF
--- a/models/ticket_history/int_zendesk__field_history_pivot.sql
+++ b/models/ticket_history/int_zendesk__field_history_pivot.sql
@@ -94,7 +94,6 @@ with field_history as (
 
     select 
         *,
-        coalesce(lead(date_day) over (partition by ticket_id order by date_day), {{ dbt_utils.dateadd("day", 1, "current_date") }}) as ending_day,
         {{ dbt_utils.surrogate_key(['ticket_id','date_day'])}} as ticket_day_id
     from pivot
 

--- a/models/ticket_history/int_zendesk__field_history_pivot.sql
+++ b/models/ticket_history/int_zendesk__field_history_pivot.sql
@@ -19,8 +19,7 @@ with field_history as (
         ticket_id,
         field_name,
         valid_ending_at,
-        valid_starting_at,
-        max(cast( {{ dbt_utils.date_trunc('day', 'valid_starting_at') }} as date)) over (partition by ticket_id) as latest_change
+        valid_starting_at
 
         --Only runs if the user passes updater fields through the final ticket field history model
         {% if var('ticket_field_history_updater_columns') %}
@@ -33,6 +32,9 @@ with field_history as (
         ,case when value is null then 'is_null' else value end as value
 
     from {{ ref('int_zendesk__field_history_enriched') }}
+    {% if is_incremental() %}
+    where cast( {{ dbt_utils.date_trunc('day', 'valid_starting_at') }} as date) >= (select max(date_day) from {{ this }})
+    {% endif %}
 
 ), event_order as (
 
@@ -86,12 +88,6 @@ with field_history as (
         {% endfor %}
     
     from filtered
-
-    --Only pull through the latest date the ticket was changed
-    {% if is_incremental() %}
-    where latest_change = cast( {{ dbt_utils.date_trunc('day', 'valid_starting_at') }} as date)
-    {% endif %}
-
     group by 1,2
 
 ), surrogate_key as (

--- a/models/ticket_history/int_zendesk__field_history_scd.sql
+++ b/models/ticket_history/int_zendesk__field_history_scd.sql
@@ -13,8 +13,7 @@ with change_data as (
 -- each row of the pivoted table includes field values if that field was updated on that day
 -- we need to backfill to persist values that have been previously updated and are still valid 
     select 
-        date_day as valid_from, 
-        cast({{ dbt_utils.date_trunc('day', 'ending_day') }} as date) as valid_to,
+        date_day as valid_from,
         ticket_id,
         ticket_day_id
 
@@ -32,7 +31,6 @@ with change_data as (
 ), fill_values as (
     select
         valid_from, 
-        valid_to,
         ticket_id,
         ticket_day_id
 

--- a/models/zendesk__ticket_field_history.sql
+++ b/models/zendesk__ticket_field_history.sql
@@ -95,3 +95,4 @@ with change_data as (
 
 select *
 from surrogate_key
+


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
This PR introduces major changes to the `int_zendesk__field_history_pivot` and `zendesk__ticket_field_history` models. Previously the incremental model would not pull down the previous field values if there was no change. The incremental update would only pull through `null` records. See below for a specific ticket example on the old incremental method:
![image](https://user-images.githubusercontent.com/74217849/134925937-ea35c75d-69ae-4ed4-a3f5-3e71681b1a10.png)
> As you can see the `--full-refresh` or initial load of the table for the dates before 2021-09-26 worked as intended, but since the ticket did not change, the model did not update the values as intended. It should have pulled through the last status through to the next date.

With the reworked incremental changes we can now see that the previous date(s) status will pull through even if there is no field change.
![image](https://user-images.githubusercontent.com/74217849/134926481-28ccd67d-3325-4ee3-b519-ce705359f7df.png)
> One item to call out is the `valid_to` will continue to change with each day's incremental load. My proposal for this would be to possibly leave this null for the time being if there is no change. Thoughts?

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [X] Yes (please provide breaking change details below.)
- [ ] No  (please provide explanation how the change is non breaking below.)

As this will undoubtedly introduces incremental changes this would require the user to perform a `--full-refresh` which would constitute a breaking change. In the future, with the release of dbt v0.21.0 this would no longer cause a breaking changes with the schema capture functionality to automatically detect when a full refresh is needed. However, for now it will need to be a breaking change.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes, Issue [link issue number here]
- [X] No 

However, this issue was raised internally and this PR addresses our internal use case.

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

As well as ad hoc testing for data validation within BigQuery

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 

🚁 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
