### PR TITLE
doc(zendesk): Fix relative links in Zendesk transform README

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ vars:
 ```
 ## Opinionated Modelling Decisions
 ### Business Time Metrics Logic
-This dbt package takes an opinionated stance on how business time metrics are calculated. The dbt package takes **all** schedules into account when calculating the business time duration. Whereas, the Zendesk UI logic takes into account **only** the latest schedule assigned to the ticket. If you would like a deeper explanation of the logic used by default in the dbt package you may reference the [DECISIONLOG](/DECISIONLOG.md).
+This dbt package takes an opinionated stance on how business time metrics are calculated. The dbt package takes **all** schedules into account when calculating the business time duration. Whereas, the Zendesk UI logic takes into account **only** the latest schedule assigned to the ticket. If you would like a deeper explanation of the logic used by default in the dbt package you may reference the [DECISIONLOG](https://github.com/fivetran/dbt_zendesk/blob/main/DECISIONLOG.md).
 ## Database support
 This package is compatible with BigQuery, Snowflake, Redshift and Postgres.
 


### PR DESCRIPTION
Closes https://fivetran.height.app/T-228344

Replaces relative links with absolute links that do not break when rendered in our docs.
