### PR TITLE
add not statement for multi touch resolution metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_zendesk v0.8.4
+## Bug Fix
+- Quick fix on missing logic in the case statement for determining multi-touch resolution metrics.
 # dbt_zendesk v0.8.3
 ## Features
 - This [Zendesk Source package](https://github.com/fivetran/dbt_zendesk_source) now allows for custom fields to be added to the `stg_zendesk__ticket` model. These custom fields will also persist downstream to the `zendesk__ticket_enriched` and `zendesk__ticket_metrics` models. You may now add your own customer fields to these models by leveraging the `zendesk__ticket_passthrough_columns` variable. ([#70](https://github.com/fivetran/dbt_zendesk/pull/70))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'zendesk'
-version: '0.8.3'
+version: '0.8.4'
 
 config-version: 2
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,7 +1,7 @@
 config-version: 2
 
 name: 'zendesk_integration_tests'
-version: '0.8.3'
+version: '0.8.4'
 
 profile: 'integration_tests'
 

--- a/models/zendesk__ticket_enriched.sql
+++ b/models/zendesk__ticket_enriched.sql
@@ -93,7 +93,7 @@ with ticket as (
         requester_org.updated_at as requester_organization_updated_at,
         submitter.external_id as submitter_external_id,
         submitter.role as submitter_role,
-        case when submitter.role in ('Agent','Admin') 
+        case when submitter.role in ('agent','admin') 
             then true 
             else false
                 end as is_agent_submitted,

--- a/models/zendesk__ticket_metrics.sql
+++ b/models/zendesk__ticket_metrics.sql
@@ -122,7 +122,8 @@ select
     then true
     else false 
       end as is_two_touch_resolution,
-  case when lower(ticket_enriched.status) in ('solved','closed') and not ticket_comments.is_one_touch_resolution 
+  case when lower(ticket_enriched.status) in ('solved','closed') and not ticket_comments.is_one_touch_resolution
+      and not ticket_comments.is_two_touch_resolution 
     then true
     else false 
       end as is_multi_touch_resolution


### PR DESCRIPTION
Pull Request
**Are you a current Fivetran customer?** 
Tony Tushar, Sr Analytics Engineer, Apto Payments

**What change(s) does this PR introduce?** 
PR is a quick fix on a missing logic in a case statement for determining multi-touch resolution metric. I noticed in our data that 32k records were being defined as both two and multi-touch = 1, so this fix corrects for that.

Additional fix on `is_agent_submitted` case statement where admin, agent should be all lowercase.

**Did you update the CHANGELOG?** 
- [x] Yes

**Does this PR introduce a breaking change?**
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide an explanation as to how the change is non-breaking below.)

This change is a minor additional clause in a case statement, no breaking changes introduced by this.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
- [x] Yes

**Is this PR in response to a previously created Bug or Feature Request**
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [x] No 

**How did you test the PR changes?** 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Local (please provide additional testing details below)

I initially ran this statement in my project and received 32k records in response where `is_two_touch_resolution` and `is_multi_touch_resolution` both equal `True`. Once I made the change suggested in this PR, I did not receive any rows back.

```
select
  ticket_id,
  sum(case when is_one_touch_resolution = true then 1 else 0 end) as one_touch_count,
  sum(case when is_two_touch_resolution = true then 1 else 0 end) as two_touch_count,
  sum(case when is_multi_touch_resolution = true then 1 else 0 end) as multi_touch_count,
from [data]
group by 1
having (sum(case when is_two_touch_resolution = true then 1 else 0 end) = 1
and sum(case when is_multi_touch_resolution = true then 1 else 0 end) = 1)
or ((sum(case when is_one_touch_resolution = true then 1 else 0 end) = 1
and sum(case when is_multi_touch_resolution = true then 1 else 0 end) = 1))
or (sum(case when is_one_touch_resolution = true then 1 else 0 end) = 1
and sum(case when is_two_touch_resolution = true then 1 else 0 end) = 1);
```

**Select which warehouse(s) were used to test the PR**
- [x] BigQuery
- [ ] Redshift
- [ ] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:sunglasses:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
