### PR TITLE
fix(int_zendesk__schedule_spine): offset holiday start and end time too

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,8 +1,0 @@
-# Default ignored files
-/shelf/
-/workspace.xml
-# Editor-based HTTP Client requests
-/httpRequests/
-# Datasource local storage ignored files
-/dataSources/
-/dataSources.local.xml


### PR DESCRIPTION
**Please provide your name and company**
Craig Homan - Beam Benefits

**Link the issue/feature request which this PR is meant to address**
<!--- If an issue was not created, please create one first so we may discuss the PR prior to opening one. -->
https://github.com/fivetran/dbt_zendesk/issues/117

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**

We now offset the start / end times as well for a holiday day, as well.

This now allows to better align to the schedule start / end times which have already been offset.

**How did you validate the changes introduced within this PR?**

I overwrote `int_zendesk__schedule_spine` in our local project, with these updates, and got the results we expected to see.  

Obviously want someone to take a 'wider' look at it, but wanted to offer a jump start since I had been investigating it on our side and saw a potential fix for our narrowed situation and temporarily overwriting the model in our project worked.  

**Which warehouse did you use to develop these changes?**

BigQuery

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
☕ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.

**PR Template** 
- [Community Pull Request Template](?expand=1&template=pull_request_template.md) (default)

- [Maintainer Pull Request Template](?expand=1&template=maintainer_pull_request_template.md) (to be used by maintainers)