### PR TITLE
feature/first_reply_time_hours_performance_fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 - Fixes the issue of `sla_event_id`'s occurring in the `zendesk__sla_policies` model.
   - This involved updating the `int_zendesk__schedule_spine` which was previously outputting overlapping schedule windows, to account for when holidays transcended a given schedule week.
   - This also involved updating the `int_zendesk__reply_time_business_hours` model, where within the model two different versions of a schedule would exist due to daylight savings time.
-
+  - Adjusted the `int_zendesk__reply_time_business_hours` model to only perform the weeks cartesian join on tickets that require the further look into the future.
+    - Previously the `int_zendesk__reply_time_business_hours` would perform a cartesian join on all tickets to calculate weeks into the future. This was required to accurately calculate sla elapsed time for tickets with first replies far into the future. However, this was only necessary for a handful of tickets. Therefore, this has been adjusted to accurately only calculate the future weeks as far as either the first reply time or first solved time.
 
 ## Documentation Updates
 - Addition of the reference to the Fivetran prebuilt [Zendesk Streamlit report](https://fivetran-zendesk.streamlit.app/) in the README.

--- a/models/sla_policy/reply_time/int_zendesk__reply_time_business_hours.sql
+++ b/models/sla_policy/reply_time/int_zendesk__reply_time_business_hours.sql
@@ -79,10 +79,23 @@ with ticket_schedules as (
     and metric in ('next_reply_time', 'first_reply_time')
 
 ), first_reply_solve_times as (
-  select 
-    ticket_sla_applied_with_schedules.*,
-    min(reply_at) as first_reply_time,
-    min(solved_at) as first_solved_time
+  select
+    ticket_sla_applied_with_schedules.ticket_id,
+    ticket_sla_applied_with_schedules.ticket_created_at,
+    ticket_sla_applied_with_schedules.valid_starting_at,
+    ticket_sla_applied_with_schedules.ticket_current_status,
+    ticket_sla_applied_with_schedules.metric,
+    ticket_sla_applied_with_schedules.latest_sla,
+    ticket_sla_applied_with_schedules.sla_applied_at,
+    ticket_sla_applied_with_schedules.target,
+    ticket_sla_applied_with_schedules.in_business_hours,
+    ticket_sla_applied_with_schedules.sla_policy_name,
+    ticket_sla_applied_with_schedules.schedule_id,
+    ticket_sla_applied_with_schedules.start_time_in_minutes_from_week,
+    ticket_sla_applied_with_schedules.total_schedule_weekly_business_minutes,
+    ticket_sla_applied_with_schedules.start_week_date,
+    min(reply_time.reply_at) as first_reply_time,
+    min(ticket_solved_times.solved_at) as first_solved_time
   from ticket_sla_applied_with_schedules
   left join reply_time
     on reply_time.ticket_id = ticket_sla_applied_with_schedules.ticket_id
@@ -106,7 +119,7 @@ with ticket_schedules as (
     -- because time is reported in minutes since the beginning of the week, we have to split up time spent on the ticket into calendar weeks
     select
       week_index_calc.*,
-      cast(generated_number - 1 as {{ dbt.type_int() }}) as week_number
+      cast(weeks.generated_number - 1 as {{ dbt.type_int() }}) as week_number
 
     from week_index_calc
     cross join weeks

--- a/models/sla_policy/reply_time/int_zendesk__reply_time_combined.sql
+++ b/models/sla_policy/reply_time/int_zendesk__reply_time_combined.sql
@@ -107,11 +107,6 @@ with reply_time_calendar_hours_sla as (
     and ticket_solved_times.solved_at > reply_time_breached_at.sla_applied_at
   {{ dbt_utils.group_by(n=10) }}
 
-  {% if var('using_schedules', True) %}
-  having (in_business_hours and week_number <= min({{ dbt.datediff("reply_time_breached_at.sla_applied_at", "coalesce(reply_time.reply_at, ticket_solved_times.solved_at, " ~ dbt.current_timestamp() ~ ")", 'week') }}))
-    or not in_business_hours
-  {% endif %}
-
 ), lagging_time_block as (
   select
     *,


### PR DESCRIPTION
## PR Overview
**This PR will address the following Issue/Feature:** #151 

**This PR will result in the following new package version:** v0.14.1
<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->

This will be a non breaking change and planned to be incorporated into the upcoming release.

**Please provide the finalized CHANGELOG entry which details the relevant changes included in this PR:**
<!--- Copy/paste the CHANGELOG for this version below. -->

> ## Bug Fixes
>   - Adjusted the `int_zendesk__reply_time_business_hours` model to only perform the weeks cartesian join on tickets that require the further look into the future.
>     - Previously the `int_zendesk__reply_time_business_hours` would perform a cartesian join on all tickets to calculate weeks into the future. This was required to accurately calculate sla elapsed time for tickets with first replies far into the future. However, this was only necessary for a handful of tickets. Therefore, this has been adjusted to accurately only calculate the future weeks as far as either the first reply time or first solved time.

## PR Checklist
### Basic Validation
Please acknowledge that you have successfully performed the following commands locally:
- [x] dbt run –full-refresh && dbt test
- [X] dbt run (if incremental models are present) && dbt test

Before marking this PR as "ready for review" the following have been applied:
- [x] The appropriate issue has been linked, tagged, and properly assigned
- [x] All necessary documentation and version upgrades have been applied
    <!--- Be sure to update the package version in the dbt_project.yml, integration_tests/dbt_project.yml, and README if necessary. -->
- [will be regenerated in release branch] docs were regenerated (unless this PR does not include any code or yml updates)
- [X] BuildKite integration tests are passing
- [X] Detailed validation steps have been provided below

### Detailed Validation
Please share any and all of your validation steps:
<!--- Provide the steps you took to validate your changes below. -->

Detailed validation includes two customers confirming that these changes drastically improved the performance of the `int_zendesk__reply_time_business_hours` model. No further validation required. 

### If you had to summarize this PR in an emoji, which would it be?
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🚤 