### PR TITLE
feature/remove-dbtdate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-# dbt_zendesk version.version
+# dbt_zendesk 0.21.0
+
+## Dependency Changes
+- Removed the dependency on [calogica/dbt_date](https://github.com/calogica/dbt-date) as it is no longer actively maintained. To maintain functionality, key date macros have been replicated within the fivetran_date_macros folder with minimal modifications. Only macro versions supporting Fivetran Zendesk supported destinations are retained, and all have been prefixed with `fivetran_` to avoid naming conflicts.
+  - `date_part` -> `fivetran_date_part`
+  - `day_of_week` -> `fivetran_day_of_week`
+  - `n_days_ago` -> `fivetran_n_days_ago`
+  - `n_days_away` -> `fivetran_n_days_away`
+  - `today` -> `fivetran_today`
+    - Please note, this macro has been adjusted to remove the timezone conversion as all dates are intended to by in UTC for the Zendesk package use case.
+  - `week_end` -> `fivetran_week_end`
+  - `week_start` -> `fivetran_week_start`
 
 ## Documentation
 - Added Quickstart model counts to README. ([#183](https://github.com/fivetran/dbt_zendesk/pull/183))

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Include the following zendesk package version in your `packages.yml` file:
 ```yml
 packages:
   - package: fivetran/zendesk
-    version: [">=0.20.0", "<0.21.0"]
+    version: [">=0.21.0", "<0.22.0"]
 
 ```
 > **Note**: Do not include the Zendesk Support source package. The Zendesk Support transform package already has a dependency on the source in its own `packages.yml` file.
@@ -304,9 +304,6 @@ packages:
 
     - package: dbt-labs/spark_utils
       version: [">=0.3.0", "<0.4.0"]
-
-    - package: calogica/dbt_date
-      version: [">=0.9.0", "<1.0.0"]
 ```
 ## How is this package maintained and can I contribute?
 ### Package Maintenance

--- a/macros/fivetran_date_macros/fivetran_date_part.sql
+++ b/macros/fivetran_date_macros/fivetran_date_part.sql
@@ -1,0 +1,11 @@
+{% macro fivetran_date_part(datepart, date) -%}
+    {{ adapter.dispatch('fivetran_date_part', 'zendesk') (datepart, date) }}
+{%- endmacro %}
+
+{% macro default__fivetran_date_part(datepart, date) -%}
+    date_part('{{ datepart }}', {{  date }})
+{%- endmacro %}
+
+{% macro bigquery__fivetran_date_part(datepart, date) -%}
+    extract({{ datepart }} from {{ date }})
+{%- endmacro %}

--- a/macros/fivetran_date_macros/fivetran_date_part.sql
+++ b/macros/fivetran_date_macros/fivetran_date_part.sql
@@ -1,5 +1,5 @@
 {% macro fivetran_date_part(datepart, date) -%}
-    {{ adapter.dispatch('fivetran_date_part', 'zendesk') (datepart, date) }}
+    {{ return(adapter.dispatch('fivetran_date_part', 'zendesk') (datepart, date)) }}
 {%- endmacro %}
 
 {% macro default__fivetran_date_part(datepart, date) -%}

--- a/macros/fivetran_date_macros/fivetran_day_of_week.sql
+++ b/macros/fivetran_date_macros/fivetran_day_of_week.sql
@@ -1,0 +1,97 @@
+{%- macro fivetran_day_of_week(date, isoweek=true) -%}
+{{ adapter.dispatch('fivetran_day_of_week', 'zendesk') (date, isoweek) }}
+{%- endmacro %}
+
+{%- macro default__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- set dow = zendesk.fivetran_date_part('dayofweek', date) -%}
+
+    {%- if isoweek -%}
+    case
+        -- Shift start of week from Sunday (0) to Monday (1)
+        when {{ dow }} = 0 then 7
+        else {{ dow }}
+    end
+    {%- else -%}
+    {{ dow }} + 1
+    {%- endif -%}
+
+{%- endmacro %}
+
+{%- macro snowflake__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- if isoweek -%}
+        {%- set dow_part = 'dayofweekiso' -%}
+        {{ zendesk.fivetran_date_part(dow_part, date) }}
+    {%- else -%}
+        {%- set dow_part = 'dayofweek' -%}
+        case
+            when {{ zendesk.fivetran_date_part(dow_part, date) }} = 7 then 1
+            else {{ zendesk.fivetran_date_part(dow_part, date) }} + 1
+        end
+    {%- endif -%}
+
+
+
+{%- endmacro %}
+
+{%- macro bigquery__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- set dow = zendesk.fivetran_date_part('dayofweek', date) -%}
+
+    {%- if isoweek -%}
+    case
+        -- Shift start of week from Sunday (1) to Monday (2)
+        when {{ dow }} = 1 then 7
+        else {{ dow }} - 1
+    end
+    {%- else -%}
+    {{ dow }}
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{%- macro postgres__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- if isoweek -%}
+        {%- set dow_part = 'isodow' -%}
+        -- Monday(1) to Sunday (7)
+        cast({{ zendesk.fivetran_date_part(dow_part, date) }} as {{ dbt.type_int() }})
+    {%- else -%}
+        {%- set dow_part = 'dow' -%}
+        -- Sunday(1) to Saturday (7)
+        cast({{ zendesk.fivetran_date_part(dow_part, date) }} + 1 as {{ dbt.type_int() }})
+    {%- endif -%}
+
+{%- endmacro %}
+
+
+{%- macro redshift__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- set dow = zendesk.fivetran_date_part('dayofweek', date) -%}
+
+    {%- if isoweek -%}
+    case
+        -- Shift start of week from Sunday (0) to Monday (1)
+        when {{ dow }} = 0 then 7
+        else cast({{ dow }} as {{ dbt.type_bigint() }})
+    end
+    {%- else -%}
+    cast({{ dow }} + 1 as {{ dbt.type_bigint() }})
+    {%- endif -%}
+
+{%- endmacro %}
+
+{%- macro duckdb__fivetran_day_of_week(date, isoweek) -%}
+{{ return(zendesk.postgres__fivetran_day_of_week(date, isoweek)) }}
+{%- endmacro %}
+
+
+{%- macro spark__fivetran_day_of_week(date, isoweek) -%}
+
+    {%- set dow = "dayofweek_iso" if isoweek else "dayofweek" -%}
+
+    {{ zendesk.fivetran_date_part(dow, date) }}
+
+{%- endmacro %}

--- a/macros/fivetran_date_macros/fivetran_day_of_week.sql
+++ b/macros/fivetran_date_macros/fivetran_day_of_week.sql
@@ -1,5 +1,5 @@
 {%- macro fivetran_day_of_week(date, isoweek=true) -%}
-{{ adapter.dispatch('fivetran_day_of_week', 'zendesk') (date, isoweek) }}
+    {{ return(adapter.dispatch('fivetran_day_of_week', 'zendesk') (date, isoweek)) }}
 {%- endmacro %}
 
 {%- macro default__fivetran_day_of_week(date, isoweek) -%}
@@ -31,8 +31,6 @@
         end
     {%- endif -%}
 
-
-
 {%- endmacro %}
 
 {%- macro bigquery__fivetran_day_of_week(date, isoweek) -%}
@@ -51,7 +49,6 @@
 
 {%- endmacro %}
 
-
 {%- macro postgres__fivetran_day_of_week(date, isoweek) -%}
 
     {%- if isoweek -%}
@@ -65,7 +62,6 @@
     {%- endif -%}
 
 {%- endmacro %}
-
 
 {%- macro redshift__fivetran_day_of_week(date, isoweek) -%}
 
@@ -86,7 +82,6 @@
 {%- macro duckdb__fivetran_day_of_week(date, isoweek) -%}
 {{ return(zendesk.postgres__fivetran_day_of_week(date, isoweek)) }}
 {%- endmacro %}
-
 
 {%- macro spark__fivetran_day_of_week(date, isoweek) -%}
 

--- a/macros/fivetran_date_macros/fivetran_n_days_ago.sql
+++ b/macros/fivetran_date_macros/fivetran_n_days_ago.sql
@@ -1,0 +1,9 @@
+{%- macro fivetran_n_days_ago(n, date=None, tz=None) -%}
+{%- set dt = date if date else zendesk.fivetran_today(tz) -%}
+{%- set n = n|int -%}
+{{ adapter.dispatch('fivetran_n_days_ago', 'zendesk') (n, date, tz) }}
+{%- endmacro -%}
+
+{%- macro default__fivetran_n_days_ago(n, date, tz) -%}
+cast({{ dbt.dateadd('day', -1 * n, dt) }} as date)
+{%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_n_days_ago.sql
+++ b/macros/fivetran_date_macros/fivetran_n_days_ago.sql
@@ -1,9 +1,11 @@
 {%- macro fivetran_n_days_ago(n, date=None, tz=None) -%}
-{%- set dt = date if date else zendesk.fivetran_today(tz) -%}
-{%- set n = n|int -%}
-{{ adapter.dispatch('fivetran_n_days_ago', 'zendesk') (n, date, tz) }}
+    {%- set dt = date if date else zendesk.fivetran_today(tz) -%}
+    {%- set n = n|int -%}
+    {{ return(adapter.dispatch('fivetran_n_days_ago', 'zendesk') (n, date, tz)) }}
 {%- endmacro -%}
 
 {%- macro default__fivetran_n_days_ago(n, date, tz) -%}
-cast({{ dbt.dateadd('day', -1 * n, dt) }} as date)
+    {%- set dt = date if date else zendesk.fivetran_today(tz) -%}
+    {%- set n = n|int -%}
+    cast({{ dbt.dateadd('day', -1 * n, dt) }} as date)
 {%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_n_days_away.sql
+++ b/macros/fivetran_date_macros/fivetran_n_days_away.sql
@@ -1,7 +1,7 @@
 {%- macro fivetran_n_days_away(n, date=None, tz=None) -%}
-{{ adapter.dispatch('fivetran_n_days_away', 'zendesk') (n, date, tz) }}
+    {{ return(adapter.dispatch('fivetran_n_days_away', 'zendesk') (n, date, tz)) }}
 {%- endmacro -%}
 
 {%- macro default__fivetran_n_days_away(n, date, tz) -%}
-{{ zendesk.fivetran_n_days_ago(-1 * n, date, tz) }}
+    {{ zendesk.fivetran_n_days_ago(-1 * n, date, tz) }}
 {%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_n_days_away.sql
+++ b/macros/fivetran_date_macros/fivetran_n_days_away.sql
@@ -1,0 +1,7 @@
+{%- macro fivetran_n_days_away(n, date=None, tz=None) -%}
+{{ adapter.dispatch('fivetran_n_days_away', 'zendesk') (n, date, tz) }}
+{%- endmacro -%}
+
+{%- macro default__fivetran_n_days_away(n, date, tz) -%}
+{{ zendesk.fivetran_n_days_ago(-1 * n, date, tz) }}
+{%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_today.sql
+++ b/macros/fivetran_date_macros/fivetran_today.sql
@@ -1,9 +1,7 @@
 {%- macro fivetran_today(tz=None) -%}
-{{ adapter.dispatch('fivetran_today', 'zendesk') () }}
+    {{ return(adapter.dispatch('fivetran_today', 'zendesk')) (tz) }}
 {%- endmacro -%}
 
 {%- macro default__fivetran_today(tz) -%}
-
-cast({{ dbt.current_timestamp() }} as date)
-
+    cast({{ dbt.current_timestamp() }} as date)
 {%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_today.sql
+++ b/macros/fivetran_date_macros/fivetran_today.sql
@@ -1,0 +1,9 @@
+{%- macro fivetran_today(tz=None) -%}
+{{ adapter.dispatch('fivetran_today', 'zendesk') () }}
+{%- endmacro -%}
+
+{%- macro default__fivetran_today(tz) -%}
+
+cast({{ dbt.current_timestamp() }} as date)
+
+{%- endmacro -%}

--- a/macros/fivetran_date_macros/fivetran_week_end.sql
+++ b/macros/fivetran_date_macros/fivetran_week_end.sql
@@ -1,22 +1,22 @@
 {%- macro fivetran_week_end(date=None, tz=None) -%}
-{%-set dt = date if date else zendesk.fivetran_today(tz) -%}
-{{ adapter.dispatch('fivetran_week_end', 'zendesk') (dt) }}
+    {%-set dt = date if date else zendesk.fivetran_today(tz) -%}
+    {{ return(adapter.dispatch('fivetran_week_end', 'zendesk') (dt)) }}
 {%- endmacro -%}
 
 {%- macro default__fivetran_week_end(date) -%}
-{{ last_day(date, 'week') }}
+    {{ last_day(date, 'week') }}
 {%- endmacro %}
 
 {%- macro snowflake__fivetran_week_end(date) -%}
-{%- set dt = zendesk.fivetran_week_start(date) -%}
-{{ zendesk.fivetran_n_days_away(6, dt) }}
+    {%- set dt = zendesk.fivetran_week_start(date) -%}
+    {{ zendesk.fivetran_n_days_away(6, dt) }}
 {%- endmacro %}
 
 {%- macro postgres__fivetran_week_end(date) -%}
-{%- set dt = zendesk.fivetran_week_start(date) -%}
-{{ zendesk.fivetran_n_days_away(6, dt) }}
+    {%- set dt = zendesk.fivetran_week_start(date) -%}
+    {{ zendesk.fivetran_n_days_away(n=6, date=dt) }}
 {%- endmacro %}
 
 {%- macro duckdb__fivetran_week_end(date) -%}
-{{ return(zendesk.postgres__fivetran_week_end(date)) }}
+    {{ return(zendesk.postgres__fivetran_week_end(date)) }}
 {%- endmacro %}

--- a/macros/fivetran_date_macros/fivetran_week_end.sql
+++ b/macros/fivetran_date_macros/fivetran_week_end.sql
@@ -1,0 +1,22 @@
+{%- macro fivetran_week_end(date=None, tz=None) -%}
+{%-set dt = date if date else zendesk.fivetran_today(tz) -%}
+{{ adapter.dispatch('fivetran_week_end', 'zendesk') (dt) }}
+{%- endmacro -%}
+
+{%- macro default__fivetran_week_end(date) -%}
+{{ last_day(date, 'week') }}
+{%- endmacro %}
+
+{%- macro snowflake__fivetran_week_end(date) -%}
+{%- set dt = zendesk.fivetran_week_start(date) -%}
+{{ zendesk.fivetran_n_days_away(6, dt) }}
+{%- endmacro %}
+
+{%- macro postgres__fivetran_week_end(date) -%}
+{%- set dt = zendesk.fivetran_week_start(date) -%}
+{{ zendesk.fivetran_n_days_away(6, dt) }}
+{%- endmacro %}
+
+{%- macro duckdb__fivetran_week_end(date) -%}
+{{ return(zendesk.postgres__fivetran_week_end(date)) }}
+{%- endmacro %}

--- a/macros/fivetran_date_macros/fivetran_week_start.sql
+++ b/macros/fivetran_date_macros/fivetran_week_start.sql
@@ -1,10 +1,10 @@
 {%- macro fivetran_week_start(date=None, tz=None) -%}
-{%-set dt = date if date else zendesk.fivetran_today(tz) -%}
-{{ adapter.dispatch('fivetran_week_start', 'zendesk') (dt) }}
+    {%-set dt = date if date else zendesk.fivetran_today(tz) -%}
+    {{ return(adapter.dispatch('fivetran_week_start', 'zendesk') (dt)) }}
 {%- endmacro -%}
 
 {%- macro default__fivetran_week_start(date) -%}
-cast({{ dbt.date_trunc('week', date) }} as date)
+    cast({{ dbt.date_trunc('week', date) }} as date)
 {%- endmacro %}
 
 {%- macro snowflake__fivetran_week_start(date) -%}
@@ -17,10 +17,10 @@ cast({{ dbt.date_trunc('week', date) }} as date)
 {%- endmacro %}
 
 {%- macro postgres__fivetran_week_start(date) -%}
--- Sunday as week start date
-cast({{ dbt.dateadd('day', -1, dbt.date_trunc('week', dbt.dateadd('day', 1, date))) }} as date)
+    -- Sunday as week start date
+    cast({{ dbt.dateadd('day', -1, dbt.date_trunc('week', dbt.dateadd('day', 1, date))) }} as date)
 {%- endmacro %}
 
 {%- macro duckdb__fivetran_week_start(date) -%}
-{{ return(zendesk.postgres__fivetran_week_start(date)) }}
+    {{ return(zendesk.postgres__fivetran_week_start(date)) }}
 {%- endmacro %}

--- a/macros/fivetran_date_macros/fivetran_week_start.sql
+++ b/macros/fivetran_date_macros/fivetran_week_start.sql
@@ -1,0 +1,26 @@
+{%- macro fivetran_week_start(date=None, tz=None) -%}
+{%-set dt = date if date else zendesk.fivetran_today(tz) -%}
+{{ adapter.dispatch('fivetran_week_start', 'zendesk') (dt) }}
+{%- endmacro -%}
+
+{%- macro default__fivetran_week_start(date) -%}
+cast({{ dbt.date_trunc('week', date) }} as date)
+{%- endmacro %}
+
+{%- macro snowflake__fivetran_week_start(date) -%}
+    {#
+        Get the day of week offset: e.g. if the date is a Sunday,
+        zendesk.fivetran_day_of_week returns 1, so we subtract 1 to get a 0 offset
+    #}
+    {% set off_set = zendesk.fivetran_day_of_week(date, isoweek=False) ~ " - 1" %}
+    cast({{ dbt.dateadd("day", "-1 * (" ~ off_set ~ ")", date) }} as date)
+{%- endmacro %}
+
+{%- macro postgres__fivetran_week_start(date) -%}
+-- Sunday as week start date
+cast({{ dbt.dateadd('day', -1, dbt.date_trunc('week', dbt.dateadd('day', 1, date))) }} as date)
+{%- endmacro %}
+
+{%- macro duckdb__fivetran_week_start(date) -%}
+{{ return(zendesk.postgres__fivetran_week_start(date)) }}
+{%- endmacro %}

--- a/models/agent_work_time/int_zendesk__ticket_work_time_business.sql
+++ b/models/agent_work_time/int_zendesk__ticket_work_time_business.sql
@@ -50,7 +50,7 @@ with ticket_historical_status as (
       status_valid_starting_at,
       status_valid_ending_at,
     ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('ticket_status_crossed_with_schedule.status_schedule_start','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.status_schedule_start','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(ticket_status_crossed_with_schedule.status_schedule_start as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as start_time_in_minutes_from_week,
@@ -59,7 +59,7 @@ with ticket_historical_status as (
               'ticket_status_crossed_with_schedule.status_schedule_end',
               'second') }} /60
             ) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_status_crossed_with_schedule.status_schedule_start','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.status_schedule_start','UTC') }} as start_week_date
 
     from ticket_status_crossed_with_schedule
     {{ dbt_utils.group_by(n=8) }}

--- a/models/intermediate/int_zendesk__schedule_holiday.sql
+++ b/models/intermediate/int_zendesk__schedule_holiday.sql
@@ -16,8 +16,8 @@ with schedule as (
         schedule_id,
         cast({{ dbt.date_trunc('day', 'holiday_start_date_at') }} as {{ dbt.type_timestamp() }}) as holiday_valid_from,
         cast({{ dbt.date_trunc('day', 'holiday_end_date_at') }}  as {{ dbt.type_timestamp() }}) as holiday_valid_until,
-        cast({{ dbt_date.week_start('holiday_start_date_at','UTC') }} as {{ dbt.type_timestamp() }}) as holiday_starting_sunday,
-        cast({{ dbt_date.week_start(dbt.dateadd('week', 1, 'holiday_end_date_at'),'UTC') }} as {{ dbt.type_timestamp() }}) as holiday_ending_sunday,
+        cast({{ zendesk.fivetran_week_start('holiday_start_date_at','UTC') }} as {{ dbt.type_timestamp() }}) as holiday_starting_sunday,
+        cast({{ zendesk.fivetran_week_start(dbt.dateadd('week', 1, 'holiday_end_date_at'),'UTC') }} as {{ dbt.type_timestamp() }}) as holiday_ending_sunday,
         -- Since the spine is based on weeks, holidays that span multiple weeks need to be broken up in to weeks. First step is to find those holidays.
         {{ dbt.datediff('holiday_start_date_at', 'holiday_end_date_at', 'week') }} + 1 as holiday_weeks_spanned
     from schedule_holiday

--- a/models/intermediate/int_zendesk__schedule_timezones.sql
+++ b/models/intermediate/int_zendesk__schedule_timezones.sql
@@ -277,9 +277,9 @@ with split_timezones as (
         end_time_utc,
         schedule_valid_from,
         schedule_valid_until,
-        -- use dbt_date.week_start to ensure we truncate to Sunday
-        cast({{ dbt_date.week_start('schedule_valid_from','UTC') }} as {{ dbt.type_timestamp() }}) as schedule_starting_sunday,
-        cast({{ dbt_date.week_start('schedule_valid_until','UTC') }} as {{ dbt.type_timestamp() }}) as schedule_ending_sunday,
+        -- use zendesk.fivetran_week_start to ensure we truncate to Sunday
+        cast({{ zendesk.fivetran_week_start('schedule_valid_from','UTC') }} as {{ dbt.type_timestamp() }}) as schedule_starting_sunday,
+        cast({{ zendesk.fivetran_week_start('schedule_valid_until','UTC') }} as {{ dbt.type_timestamp() }}) as schedule_ending_sunday,
         -- Check if the start fo the schedule was from a schedule or timezone change for tracking downstream.
         case when schedule_valid_from = timezone_valid_from
             then 'timezone'

--- a/models/reply_times/int_zendesk__ticket_first_reply_time_business.sql
+++ b/models/reply_times/int_zendesk__ticket_first_reply_time_business.sql
@@ -40,7 +40,7 @@ with ticket_reply_times as (
     min(first_reply_time.agent_responded_at) as agent_responded_at,
 
     ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(ticket_schedules.schedule_created_at as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as start_time_in_minutes_from_week,
@@ -51,7 +51,7 @@ with ticket_reply_times as (
           'least(ticket_schedules.schedule_invalidated_at, min(first_reply_time.agent_responded_at))',
           'second') }}/60
         )) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
   
   from first_reply_time
   join ticket_schedules 

--- a/models/resolution_times/int_zendesk__ticket_first_resolution_time_business.sql
+++ b/models/resolution_times/int_zendesk__ticket_first_resolution_time_business.sql
@@ -28,7 +28,7 @@ with ticket_resolution_times_calendar as (
     min(ticket_resolution_times_calendar.first_solved_at) as first_solved_at,
 
     ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(ticket_schedules.schedule_created_at as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as start_time_in_minutes_from_week,
@@ -39,7 +39,7 @@ with ticket_resolution_times_calendar as (
           'least(ticket_schedules.schedule_invalidated_at, min(ticket_resolution_times_calendar.first_solved_at))',
           'second') }}/60
         )) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
       
   from ticket_resolution_times_calendar
   join ticket_schedules 

--- a/models/resolution_times/int_zendesk__ticket_full_resolution_time_business.sql
+++ b/models/resolution_times/int_zendesk__ticket_full_resolution_time_business.sql
@@ -27,7 +27,7 @@ with ticket_resolution_times_calendar as (
     -- bringing this in the determine which schedule (Daylight Savings vs Standard time) to use
     min(ticket_resolution_times_calendar.last_solved_at) as last_solved_at,
     ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(ticket_schedules.schedule_created_at as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as start_time_in_minutes_from_week,
@@ -38,7 +38,7 @@ with ticket_resolution_times_calendar as (
           'least(ticket_schedules.schedule_invalidated_at, min(ticket_resolution_times_calendar.last_solved_at))',
           'second') }}/60
         )) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_schedules.schedule_created_at','UTC') }} as start_week_date
       
   from ticket_resolution_times_calendar
   join ticket_schedules 

--- a/models/sla_policy/agent_work_time/int_zendesk__agent_work_time_business_hours.sql
+++ b/models/sla_policy/agent_work_time/int_zendesk__agent_work_time_business_hours.sql
@@ -62,7 +62,7 @@ with agent_work_time_filtered_statuses as (
       status_valid_starting_at,
       status_valid_ending_at,
       ({{ dbt.datediff(
-              "cast(" ~ dbt_date.week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+              "cast(" ~ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
               "cast(ticket_status_crossed_with_schedule.valid_starting_at as " ~ dbt.type_timestamp() ~ ")",
               'second') }} /60
             ) as valid_starting_at_in_minutes_from_week,
@@ -71,7 +71,7 @@ with agent_work_time_filtered_statuses as (
                 'ticket_status_crossed_with_schedule.valid_ending_at',
                 'second') }} /60
               ) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') }} as start_week_date
               
     from ticket_status_crossed_with_schedule
     {{ dbt_utils.group_by(n=11) }}
@@ -187,7 +187,7 @@ with agent_work_time_filtered_statuses as (
     {{ fivetran_utils.timestamp_add(
       "minute",
       "cast(((7*24*60) * week_number) + breach_minutes_from_week as " ~ dbt.type_int() ~ " )",
-      "cast(" ~ dbt_date.week_start('valid_starting_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ " )"
+      "cast(" ~ zendesk.fivetran_week_start('valid_starting_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ " )"
       ) }} as sla_breach_at
   from intercepted_periods_agent_filtered
 )

--- a/models/sla_policy/reply_time/int_zendesk__reply_time_business_hours.sql
+++ b/models/sla_policy/reply_time/int_zendesk__reply_time_business_hours.sql
@@ -66,12 +66,12 @@ with ticket_schedules as (
     sla_policy_applied.*,
     ticket_schedules.schedule_id,
     ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('sla_policy_applied.sla_applied_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('sla_policy_applied.sla_applied_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(sla_policy_applied.sla_applied_at as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as start_time_in_minutes_from_week,
       schedule_business_hours.total_schedule_weekly_business_minutes,
-    {{ dbt_date.week_start('sla_policy_applied.sla_applied_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('sla_policy_applied.sla_applied_at','UTC') }} as start_week_date
 
   from sla_policy_applied
   left join ticket_schedules on sla_policy_applied.ticket_id = ticket_schedules.ticket_id
@@ -183,20 +183,20 @@ with ticket_schedules as (
   select
     *,
     schedule_end_time + remaining_minutes as breached_at_minutes,
-    {{ dbt_date.week_start('sla_applied_at','UTC') }} as starting_point,
+    {{ zendesk.fivetran_week_start('sla_applied_at','UTC') }} as starting_point,
     {{ fivetran_utils.timestamp_add(
         "minute",
         "cast(((7*24*60) * week_number) + (schedule_end_time + remaining_minutes) as " ~ dbt.type_int() ~ " )",
-        "cast(" ~ dbt_date.week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_breach_at,
+        "cast(" ~ zendesk.fivetran_week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_breach_at,
     {{ fivetran_utils.timestamp_add(
         "minute",
         "cast(((7*24*60) * week_number) + (schedule_start_time) as " ~ dbt.type_int() ~ " )",
-        "cast(" ~ dbt_date.week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_schedule_start_at,
+        "cast(" ~ zendesk.fivetran_week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_schedule_start_at,
     {{ fivetran_utils.timestamp_add(
         "minute",
         "cast(((7*24*60) * week_number) + (schedule_end_time) as " ~ dbt.type_int() ~ " )",
-        "cast(" ~ dbt_date.week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_schedule_end_at,
-    {{ dbt_date.week_end("sla_applied_at", tz="America/UTC") }} as week_end_date
+        "cast(" ~ zendesk.fivetran_week_start('sla_applied_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ ")" ) }} as sla_schedule_end_at,
+    {{ zendesk.fivetran_week_end("sla_applied_at", tz="America/UTC") }} as week_end_date
   from intercepted_periods_with_breach_flag
 
 ), reply_time_business_hours_sla as (

--- a/models/sla_policy/requester_wait_time/int_zendesk__requester_wait_time_business_hours.sql
+++ b/models/sla_policy/requester_wait_time/int_zendesk__requester_wait_time_business_hours.sql
@@ -62,7 +62,7 @@ with requester_wait_time_filtered_statuses as (
       status_valid_starting_at,
       status_valid_ending_at,
       ({{ dbt.datediff(
-            "cast(" ~ dbt_date.week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
+            "cast(" ~ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') ~ "as " ~ dbt.type_timestamp() ~ ")", 
             "cast(ticket_status_crossed_with_schedule.valid_starting_at as " ~ dbt.type_timestamp() ~ ")",
             'second') }} /60
           ) as valid_starting_at_in_minutes_from_week,
@@ -71,7 +71,7 @@ with requester_wait_time_filtered_statuses as (
               'ticket_status_crossed_with_schedule.valid_ending_at',
               'second') }} /60
             ) as raw_delta_in_minutes,
-    {{ dbt_date.week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') }} as start_week_date
+    {{ zendesk.fivetran_week_start('ticket_status_crossed_with_schedule.valid_starting_at','UTC') }} as start_week_date
 
     from ticket_status_crossed_with_schedule
     {{ dbt_utils.group_by(n=11) }}
@@ -187,7 +187,7 @@ with requester_wait_time_filtered_statuses as (
     {{ fivetran_utils.timestamp_add(
       "minute",
       "cast(((7*24*60) * week_number) + breach_minutes_from_week as " ~ dbt.type_int() ~ " )",
-      "cast(" ~ dbt_date.week_start('valid_starting_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ " )"
+      "cast(" ~ zendesk.fivetran_week_start('valid_starting_at','UTC') ~ " as " ~ dbt.type_timestamp() ~ " )"
       ) }} as sla_breach_at
   from intercepted_periods_agent_filtered
 

--- a/packages.yml
+++ b/packages.yml
@@ -1,6 +1,3 @@
 packages:
   - package: fivetran/zendesk_source
     version: [">=0.15.0", "<0.16.0"]
-
-  - package: calogica/dbt_date
-    version: [">=0.9.0", "<1.0.0"]


### PR DESCRIPTION
This PR will address: Issue #186 

This PR removes the dependency on dbt_date and hosts the required macros within the Zendesk package instead.

If you would like to test this PR before official release you may use the following in your `packages.yml`.
```yml
packages:
  - git: https://github.com/fivetran/dbt_zendesk.git
    revision: feature/remove-dbtdate
    warn-unpinned: false 
```